### PR TITLE
Add -i/--private-key to GerritDownloader

### DIFF
--- a/GerritDownloader/src/main/java/com/holmsted/gerrit/CommandLineParser.java
+++ b/GerritDownloader/src/main/java/com/holmsted/gerrit/CommandLineParser.java
@@ -49,6 +49,11 @@ public class CommandLineParser {
             converter = ServerAndPort.Converter.class)
     private ServerAndPort serverAndPort;
 
+    @Parameter(names = {"-i", "--private-key"},
+            description = "The SSH private key to access the server. Defaults to ~/.ssh/id_rsa.",
+            required = false)
+    private String privateKey;
+
     @Parameter(names = {"-p", "--project"},
             description = "The Gerrit project from which to retrieve stats. This parameter can appear multiple times. "
                     + "If omitted, stats will be retrieved from all projects.")
@@ -107,6 +112,14 @@ public class CommandLineParser {
     @Nullable
     public String getServerName() {
         return serverAndPort != null ? serverAndPort.serverName : null;
+    }
+
+    @Nullable
+    public String getPrivateKey() {
+        if (privateKey != null) {
+          return privateKey;
+        }
+        return "~/.ssh/id_rsa";
     }
 
     @Nullable

--- a/GerritDownloader/src/main/java/com/holmsted/gerrit/CommandLineParser.java
+++ b/GerritDownloader/src/main/java/com/holmsted/gerrit/CommandLineParser.java
@@ -117,9 +117,12 @@ public class CommandLineParser {
     @Nullable
     public String getPrivateKey() {
         if (privateKey != null) {
-          return privateKey;
+            if (privateKey.startsWith("~" + File.separator)) {
+                privateKey = System.getProperty("user.home") + privateKey.substring(1);
+            }
+            return privateKey;
         }
-        return "~/.ssh/id_rsa";
+        return System.getProperty("user.home") + ".ssh/id_rsa";
     }
 
     @Nullable

--- a/GerritDownloader/src/main/java/com/holmsted/gerrit/GerritServer.java
+++ b/GerritDownloader/src/main/java/com/holmsted/gerrit/GerritServer.java
@@ -8,15 +8,16 @@ import javax.annotation.Nonnull;
 public class GerritServer {
 
     private static final int GERRIT_DEFAULT_PORT = 29418;
-
     private final int port;
 
     @Nonnull
     private final String serverName;
+    private final String privateKey;
 
-    public GerritServer(@Nonnull String serverName, int port) {
+    public GerritServer(@Nonnull String serverName, int port, @Nonnull String privateKey) {
         this.serverName = serverName;
         this.port = port != 0 ? port : GERRIT_DEFAULT_PORT;
+        this.privateKey = privateKey;
     }
 
     public String getServerName() {
@@ -25,6 +26,10 @@ public class GerritServer {
 
     public int getPort() {
         return port;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
     }
 
     @Override

--- a/GerritDownloader/src/main/java/com/holmsted/gerrit/GerritStatReader.java
+++ b/GerritDownloader/src/main/java/com/holmsted/gerrit/GerritStatReader.java
@@ -70,7 +70,7 @@ public class GerritStatReader {
             Runtime runtime = Runtime.getRuntime();
             try {
                 String projectNameList = createProjectNameList();
-                String command = String.format("ssh -p %s %s gerrit query %s "
+                String command = String.format("ssh -p %s -i %s %s gerrit query %s "
                                 + "--format=JSON "
                                 + "--all-approvals "
                                 + "--all-reviewers "
@@ -78,6 +78,7 @@ public class GerritStatReader {
                                 + createStartOffsetArg()
                                 + createLimitArg(),
                         String.valueOf(gerritServer.getPort()),
+                        String.valueOf(gerritServer.getPrivateKey()),
                         gerritServer.getServerName(),
                         projectNameList);
                 System.out.println(command);

--- a/GerritDownloader/src/main/java/com/holmsted/gerrit/GerritStatsDownloaderMain.java
+++ b/GerritDownloader/src/main/java/com/holmsted/gerrit/GerritStatsDownloaderMain.java
@@ -18,8 +18,10 @@ public class GerritStatsDownloaderMain {
             return;
         }
 
-        GerritServer gerritServer = new GerritServer(commandLine.getServerName(),
-                commandLine.getServerPort());
+        GerritServer gerritServer = new GerritServer(
+                commandLine.getServerName(),
+                commandLine.getServerPort(),
+                commandLine.getPrivateKey());
 
         List<String> projectNames = commandLine.getProjectNames();
         if (projectNames == null || projectNames.isEmpty()) {


### PR DESCRIPTION
It would be nice be able to specify a specific private key directly when connecting over ssh.  This could be controlled by specifying the configuration in `~/.ssh/id_rsa` too but passing in -i/--private-key seemed more convenient.

On a side note, I'm by no means a Java expert so if there's something wrong or a better way of accomplishing this I'll be happy to fix it.