### PR TITLE
Repair GerritStats/../CommandLineParser

### DIFF
--- a/GerritStats/src/main/java/com/holmsted/gerrit/CommandLineParser.java
+++ b/GerritStats/src/main/java/com/holmsted/gerrit/CommandLineParser.java
@@ -70,8 +70,8 @@ public class CommandLineParser {
     }
 
     public CommandLineParser() {
-        URLClassLoader loader = (URLClassLoader) getClass().getClassLoader();
-        URL url = loader.findResource("META-INF/MANIFEST.MF");
+        ClassLoader loader = getClass().getClassLoader();
+        URL url = loader.getResource("META-INF/MANIFEST.MF");
         try {
             Manifest manifest = new Manifest(url.openStream());
             Attributes attr = manifest.getMainAttributes();


### PR DESCRIPTION
In Java 11 the method getClass().getClassLoader() does not yield a
URLClassLoader so the cast threw Exception. Remove cast and revise
to call method getResource() to fetch the MANIFEST.MF file.

Missed this CommandLineParser occurrence in the previous PR