### PR TITLE
Silence gradle deprecation warnings in v6

### DIFF
--- a/GerritCommon/build.gradle
+++ b/GerritCommon/build.gradle
@@ -1,5 +1,6 @@
+plugins {
+    id 'java-library'
+}
 dependencies {
-    compile "org.json:json:20140107"
-    compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0'
-    compile group: 'com.google.guava', name: 'guava', version: '18.0'
+    implementation 'com.google.code.findbugs:jsr305:3.0.0'
 }

--- a/GerritDownloader/build.gradle
+++ b/GerritDownloader/build.gradle
@@ -1,7 +1,5 @@
 dependencies {
-    compile group: 'com.beust', name: 'jcommander', version: '1.48'
-
-    compile project(':GerritCommon')
+    implementation project(':GerritCommon')
 }
 
 jar {
@@ -10,5 +8,5 @@ jar {
     }
 
     // Include dependencies in JAR file (see http://stackoverflow.com/a/3450409/639421).
-    from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 }

--- a/GerritStats/build.gradle
+++ b/GerritStats/build.gradle
@@ -1,22 +1,19 @@
 plugins {
-    id 'com.moowork.node' version '0.13'
+    id 'com.moowork.node' version '1.3.1'
 }
 
 // Use a local npm version to avoid any path problems with e.g. Android Studio.
 // Note that npm is not copied into the final output although it's installed
 // as a local module.
 node {
-    npmVersion = '3.10.5'
+    npmVersion = '6.14.4'
 }
 
 dependencies {
-    compile group: 'joda-time', name: 'joda-time', version: '2.8.2'
-    compile group: 'com.beust', name: 'jcommander', version: '1.48'
-    compile group: 'com.beust', name: 'jcommander', version: '1.48'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
-
-    compile project(':GerritCommon')
+    implementation 'joda-time:joda-time:2.8.2'
+    implementation 'com.google.code.gson:gson:2.6.2'
+    implementation 'org.apache.commons:commons-lang3:3.0'
+    implementation project(':GerritCommon')
 }
 
 jar {
@@ -25,7 +22,7 @@ jar {
     }
 
     // Include dependencies in JAR file (see http://stackoverflow.com/a/3450409/639421).
-    from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 
     processResources.dependsOn npmInstall
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,10 @@ allprojects {
     group = 'com.holmsted.gerrit'
 
     dependencies {
-        compile 'com.google.code.findbugs:annotations:3.0.1'
+        implementation 'com.google.code.findbugs:annotations:3.0.1'
+        implementation 'com.google.guava:guava:18.0'
+        implementation 'org.json:json:20140107'
+        implementation 'com.beust:jcommander:1.48'
     }
 
     repositories {


### PR DESCRIPTION
Declare dependencies with implementation, drop deprecated compilation
Refactor dependencies from the two submodules into parent
Upgrade com.moowork.node plugin to version 1.3.1
Upgrade node/npm to version 6.14.4
One deprecation warning remains about NpmSetupTask:
    Property 'args' is not annotated with an input or output annotation