### PR TITLE
Repair methods that check Gerrit versions

### DIFF
--- a/GerritCommon/src/main/java/com/holmsted/gerrit/GerritVersion.java
+++ b/GerritCommon/src/main/java/com/holmsted/gerrit/GerritVersion.java
@@ -55,8 +55,9 @@ public final class GerritVersion {
         }
     }
 
+    // Version 3.1 must pass the "isAtLeast" test against 2.9 even tho 1 < 9.
     public boolean isAtLeast(int expectedMajor, int expectedMinor) {
-        return this.major >= expectedMajor && this.minor >= expectedMinor;
+        return this.major > expectedMajor || (this.major == expectedMajor && this.minor >= expectedMinor);
     }
 
     public boolean isAtLeast(@Nonnull GerritVersion otherVersion) {

--- a/GerritDownloader/src/main/java/com/holmsted/gerrit/CommandLineParser.java
+++ b/GerritDownloader/src/main/java/com/holmsted/gerrit/CommandLineParser.java
@@ -26,7 +26,8 @@ public class CommandLineParser {
     private static final String DEFAULT_OUTPUT_DIR = "out";
 
     @Parameter(names = {"-s", "--server"},
-            description = "Read output from Gerrit server URL and given port, in format server:port. "
+            description = "Download from Gerrit server name and port, in format server:port. "
+                    + "Some servers require a username; e.g., mylogin@gerrit.project.org. "
                     + "If port is omitted, defaults to 29418.",
             arity = 1,
             required = true,

--- a/GerritStats/src/main/frontend/common/GerritVersionAlerts.jsx
+++ b/GerritStats/src/main/frontend/common/GerritVersionAlerts.jsx
@@ -14,10 +14,11 @@ export default class GerritVersionAlerts extends React.Component {
         };
     }
 
+    // Version 3.1 must pass the "atLeast" test against 2.9 even tho 1 < 9.
     isGerritVersionAtLeast(major, minor) {
         var gerritVersion = this.props.datasetOverview['gerritVersion'] || {};
-        return gerritVersion['major'] >= major
-            && gerritVersion['minor'] >= minor;
+        return gerritVersion['major'] > major || 
+            (gerritVersion['major'] == major && gerritVersion['minor'] >= minor);
     }
 
     isGerritVersionUnknown() {


### PR DESCRIPTION
Version 3.1 must pass the "atLeast" test against 2.9 even tho 1 < 9
in both Java and Javascript.